### PR TITLE
[Fix.] Deprecate ECMQueryQmake, superseded by ECMQueryQt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.16)
 
 project(lingmo-qt-plugins)
 

--- a/widgetstyle/CMakeLists.txt
+++ b/widgetstyle/CMakeLists.txt
@@ -14,7 +14,7 @@ find_package(Qt5 REQUIRED ${QT})
 find_package(PkgConfig REQUIRED)
 find_package(KF5 REQUIRED WindowSystem)
 
-include(ECMQueryQmake)
+include(ECMQueryQt)
 
 set (SRCS
     blurhelper.cpp
@@ -44,6 +44,6 @@ target_link_libraries(${TARGET}
     KF5::WindowSystem
     )
 
-query_qmake(CMAKE_INSTALL_QTPLUGINDIR QT_INSTALL_PLUGINS)
+ecm_query_qt(CMAKE_INSTALL_QTPLUGINDIR QT_INSTALL_PLUGINS)
 
 install(TARGETS ${TARGET} DESTINATION ${CMAKE_INSTALL_QTPLUGINDIR}/styles/)


### PR DESCRIPTION
ECMQueryQmake is deprecated. Using ECMQueryQt instead.

See https://github.com/KDE/extra-cmake-modules/commit/c34c6730dcfb4320ff3a18f4dc2accf157550fe8